### PR TITLE
Log processed rows to the csvimport.management.commands.csvimport logger

### DIFF
--- a/csvimport/management/commands/csvimport.py
+++ b/csvimport/management/commands/csvimport.py
@@ -10,6 +10,9 @@ from django.core.management.base import LabelCommand, BaseCommand
 from optparse import make_option
 from django.db import models
 
+import logging
+logger = logging.getLogger(__name__)
+
 INTEGER = ['BigIntegerField', 'IntegerField', 'AutoField',
            'PositiveIntegerField', 'PositiveSmallIntegerField']
 FLOAT = ['DecimalField', 'FloatField']
@@ -182,6 +185,7 @@ class Command(LabelCommand):
                                 (self.model._meta.app_label, self.model.__name__))
             return self.loglist
         for row in self.csvfile[1:]:
+            logger.info("Import %s %i", self.model.__name__, counter)
             counter += 1
             model_instance = self.model()
             model_instance.csvimport_id = csvimportid


### PR DESCRIPTION
I found it useful to have optional logging of processed rows when importing large CSVs. Configure the csvimport.management.commands.csvimport logger appropriately to enable/disable logging.
