### PR TITLE
Import re in csvimport/models.py

### DIFF
--- a/csvimport/models.py
+++ b/csvimport/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.conf import settings 
 from django.core.files.storage import FileSystemStorage
+import re
 
 fs = FileSystemStorage(location=settings.MEDIA_ROOT)
 CHOICES = (('manual','manual'),('cronjob','cronjob'))


### PR DESCRIPTION
Throwing a global name 're' is not defined.  Fixed by importing re in the models.py.
