### PR TITLE
Allow for missing/blank SmallIntegerField

### DIFF
--- a/csvimport/management/commands/csvimport.py
+++ b/csvimport/management/commands/csvimport.py
@@ -19,7 +19,7 @@ if CSVIMPORT_LOG == 'logger':
     import logging
     logger = logging.getLogger(__name__)
 
-INTEGER = ['BigIntegerField', 'IntegerField', 'AutoField',
+INTEGER = ['BigIntegerField', 'IntegerField', 'SmallIntegerField', 'AutoField',
            'PositiveIntegerField', 'PositiveSmallIntegerField']
 FLOAT = ['DecimalField', 'FloatField']
 NUMERIC = INTEGER + FLOAT


### PR DESCRIPTION
Hi - my import was failing because of a blank value in my csv corresponding to a SmallIntegerField in my model.  I added this small change to fix this.
