### PR TITLE
Fix runaway memory use

### DIFF
--- a/csvimport/management/commands/importcsv.py
+++ b/csvimport/management/commands/importcsv.py
@@ -138,7 +138,8 @@ class Command(LabelCommand, CSVParser):
             save_csvimport(self.props, self)
         # can cause memoryerror if its too big
         try:
-            for error in errors:
+            errors_copy = errors [:]
+            for error in errors_copy:
                 self.loglist.append(errors)
         except:
             pass


### PR DESCRIPTION
Fix runaway memory use, formerly it was adding one to the end of array while looping through it :-D
Solution: make a copy first - JJW
