### PR TITLE
Fixes #65: Remove use of ForeignObject.related_field

### DIFF
--- a/csvimport/management/commands/importcsv.py
+++ b/csvimport/management/commands/importcsv.py
@@ -423,8 +423,8 @@ class Command(LabelCommand, CSVParser):
                     key += '(%s|%s)' % (field.related.parent_model.__name__,
                                         field.related.parent_model._meta.fields[1].name,)
                 else:
-                    key += '(%s|%s)' % (field.related_field.model.__name__,
-                                        field.related_field.model._meta.fields[1].name,)
+                    key += '(%s|%s)' % (field.related_model.__name__,
+                                        field.related_model._meta.fields[1].name,)
 
         return key
 


### PR DESCRIPTION
Removed in Django 1.9. Replace with ForeignObject.related_model.
