### PR TITLE
Fix #61,67 - Support for Django 1.8+

### DIFF
--- a/csvimport/management/commands/importcsv.py
+++ b/csvimport/management/commands/importcsv.py
@@ -30,7 +30,7 @@ SMALLINT_DBS = ['sqlite3', ]
 DATE = ['DateField', 'TimeField', 'DateTimeField']
 BOOLEAN = ['BooleanField', 'NullBooleanField']
 BOOLEAN_TRUE = [1, '1', 'Y', 'Yes', 'yes', 'True', 'true', 'T', 't']
-DATE_INPUT_FORMATS = settings.DATE_INPUT_FORMATS or ('%d/%m/%Y','%Y/%m/%d')
+DATE_INPUT_FORMATS = tuple(settings.DATE_INPUT_FORMATS) or ('%d/%m/%Y','%Y/%m/%d')
 CSV_DATE_INPUT_FORMATS = DATE_INPUT_FORMATS + ('%d-%m-%Y','%Y-%m-%d')
 cleancol = re.compile('[^0-9a-zA-Z]+')  # cleancol.sub('_', s)
 
@@ -76,7 +76,7 @@ class Command(LabelCommand, CSVParser):
     as is.
     """
 
-    option_list = BaseCommand.option_list + (
+    option_list = getattr(BaseCommand, 'option_list',()) + (
                make_option('--mappings', default='',
                            help='''Provide comma separated column names or format like
                                    (column1=field1(ForeignKey|field),column2=field2(ForeignKey|field), ...)

--- a/csvimport/management/commands/importcsv.py
+++ b/csvimport/management/commands/importcsv.py
@@ -5,6 +5,8 @@ import os, csv, re
 from datetime import datetime
 import codecs
 import chardet
+import django
+from distutils.version import StrictVersion
 
 from django.db import DatabaseError
 from django.core.exceptions import ObjectDoesNotExist
@@ -30,7 +32,13 @@ SMALLINT_DBS = ['sqlite3', ]
 DATE = ['DateField', 'TimeField', 'DateTimeField']
 BOOLEAN = ['BooleanField', 'NullBooleanField']
 BOOLEAN_TRUE = [1, '1', 'Y', 'Yes', 'yes', 'True', 'true', 'T', 't']
-DATE_INPUT_FORMATS = tuple(settings.DATE_INPUT_FORMATS) or ('%d/%m/%Y','%Y/%m/%d')
+
+#Adding Support for Django 1.9+
+if StrictVersion(django.get_version()) >= StrictVersion('1.9.0'):
+    DATE_INPUT_FORMATS = tuple(settings.DATE_INPUT_FORMATS) or ('%d/%m/%Y','%Y/%m/%d')
+else:
+    DATE_INPUT_FORMATS = settings.DATE_INPUT_FORMATS or ('%d/%m/%Y','%Y/%m/%d')
+
 CSV_DATE_INPUT_FORMATS = DATE_INPUT_FORMATS + ('%d-%m-%Y','%Y-%m-%d')
 cleancol = re.compile('[^0-9a-zA-Z]+')  # cleancol.sub('_', s)
 
@@ -76,19 +84,26 @@ class Command(LabelCommand, CSVParser):
     as is.
     """
 
-    option_list = getattr(BaseCommand, 'option_list',()) + (
-               make_option('--mappings', default='',
-                           help='''Provide comma separated column names or format like
-                                   (column1=field1(ForeignKey|field),column2=field2(ForeignKey|field), ...)
-                                   for the import (use none for no names -> col_#)'''),
-               make_option('--defaults', default='',
-                           help='''Provide comma separated defaults for the import 
-                                   (field1=value,field3=value, ...)'''),
-               make_option('--model', default='iisharing.Item',
-                           help='Please provide the model to import to'),
-               make_option('--charset', default='',
-                           help='Force the charset conversion used rather than detect it')
-                   )
+    make_options = (
+                       make_option('--mappings', default='',
+                                   help='''Provide comma separated column names or format like
+                                           (column1=field1(ForeignKey|field),column2=field2(ForeignKey|field), ...)
+                                           for the import (use none for no names -> col_#)'''),
+                       make_option('--defaults', default='',
+                                   help='''Provide comma separated defaults for the import 
+                                           (field1=value,field3=value, ...)'''),
+                       make_option('--model', default='iisharing.Item',
+                                   help='Please provide the model to import to'),
+                       make_option('--charset', default='',
+                                   help='Force the charset conversion used rather than detect it')
+                    )
+
+    # Adding support for Django 1.10+
+    if StrictVersion(django.get_version()) >= StrictVersion('1.10.0'):
+        option_list = getattr(BaseCommand, 'option_list',()) + make_options
+    else:
+        option_list = BaseCommand.option_list + make_options
+
     help = "Imports a CSV file to a model"
 
 

--- a/csvimport/management/commands/inspectcsv.py
+++ b/csvimport/management/commands/inspectcsv.py
@@ -2,6 +2,9 @@
     Django command to import CSV files
 """
 import re
+import django
+from distutils.version import StrictVersion
+
 from optparse import make_option
 from django.core.management.base import LabelCommand, BaseCommand
 
@@ -16,15 +19,22 @@ class Command(LabelCommand, CSVParser):
     Inspect a CSV resource to generate the code for a Django model.
     """
 
-    option_list = getattr(BaseCommand, 'option_list',()) + (
-               make_option('--defaults', default='',
-                           help='''Provide comma separated defaults for the import 
-                                   (field1=value,field3=value, ...)'''),
-               make_option('--model', default='',
-                           help='Please provide the model to import to'),
-               make_option('--charset', default='',
-                           help='Force the charset conversion used rather than detect it')
+    make_options = (
+                   make_option('--defaults', default='',
+                               help='''Provide comma separated defaults for the import 
+                                       (field1=value,field3=value, ...)'''),
+                   make_option('--model', default='',
+                               help='Please provide the model to import to'),
+                   make_option('--charset', default='',
+                               help='Force the charset conversion used rather than detect it')
                    )
+    
+    # Adding support for Django 1.10+
+    if StrictVersion(django.get_version()) >= StrictVersion('1.10.0'):
+        option_list = getattr(BaseCommand, 'option_list',()) + make_options
+    else:
+        option_list = BaseCommand.option_list + make_options
+
     help = "Analyses CSV file date to generate a Django model"
 
     def __init__(self):

--- a/csvimport/management/commands/inspectcsv.py
+++ b/csvimport/management/commands/inspectcsv.py
@@ -16,7 +16,7 @@ class Command(LabelCommand, CSVParser):
     Inspect a CSV resource to generate the code for a Django model.
     """
 
-    option_list = BaseCommand.option_list + (
+    option_list = getattr(BaseCommand, 'option_list',()) + (
                make_option('--defaults', default='',
                            help='''Provide comma separated defaults for the import 
                                    (field1=value,field3=value, ...)'''),


### PR DESCRIPTION
Issue #67 of Base Command addressed
Issue #61 of DATE_INPUT_FORMATS addressed

Supports only Django 1.8 and later. No backward compatibility. Let me know if I should build a version hack for the same.
