### PR TITLE
Remove extra quotes around migration

### DIFF
--- a/csvimport/migrations/0002_test_models.py
+++ b/csvimport/migrations/0002_test_models.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'managed': True,
-                'db_table': '"csvtests_country"',
+                'db_table': 'csvtests_country',
             },
         ),
         migrations.CreateModel(


### PR DESCRIPTION
Extra quotes around the csvtest_country migration (two sets of quotes - single around double) cause the migration to fail with am internal Django error